### PR TITLE
feat(boards): Add glove80 nexus node for extension GPIO.

### DIFF
--- a/app/boards/arm/glove80/glove80_lh.dts
+++ b/app/boards/arm/glove80/glove80_lh.dts
@@ -36,6 +36,21 @@
     vbatt: vbatt {
         compatible = "zmk,battery-nrf-vddh";
     };
+
+    glove80_ext: connector {
+        compatible = "moergo-glove80-ext";
+        #gpio-cells = <2>;
+        gpio-map-mask = <0xffffffff 0xffffffc0>;
+        gpio-map-pass-thru = <0 0x3f>;
+        gpio-map
+            = <1 0 &gpio0 22 0>     /* EXT1 */
+            , <2 0 &gpio0 21 0>     /* EXT2 */
+            , <3 0 &gpio0 24 0>     /* EXT3 */
+            , <4 0 &gpio0 20 0>     /* EXT4 */
+            , <5 0 &gpio0 25 0>     /* EXT5 */
+            , <6 0 &gpio1 00 0>     /* EXT6 */
+            ;
+    };
 };
 
 &spi3 {
@@ -94,4 +109,5 @@
         , <&gpio1 3 GPIO_ACTIVE_HIGH> // LH COL1
         , <&gpio1 1 GPIO_ACTIVE_HIGH> // LH Thumb
         ;
+
 };

--- a/app/boards/arm/glove80/glove80_rh.dts
+++ b/app/boards/arm/glove80/glove80_rh.dts
@@ -37,6 +37,21 @@
     vbatt: vbatt {
         compatible = "zmk,battery-nrf-vddh";
     };
+
+    glove80_ext: connector {
+        compatible = "moergo-glove80-ext";
+        #gpio-cells = <2>;
+        gpio-map-mask = <0xffffffff 0xffffffc0>;
+        gpio-map-pass-thru = <0 0x3f>;
+        gpio-map
+            = <1 0 &gpio0 21 0>     /* EXT1 */
+            , <2 0 &gpio0 24 0>     /* EXT2 */
+            , <3 0 &gpio0 20 0>     /* EXT3 */
+            , <4 0 &gpio0 25 0>     /* EXT4 */
+            , <5 0 &gpio0 22 0>     /* EXT5 */
+            , <6 0 &gpio1 00 0>     /* EXT6 */
+            ;
+    };
 };
 
 &spi3 {


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [ ] `.zmk.yml` metadata file added
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] General consistent formatting of DeviceTree files
- [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
